### PR TITLE
In Symfony 4, execute() needs to return an int always

### DIFF
--- a/src/app/CliTools/Console/Command/Common/FixRightsCommand.php
+++ b/src/app/CliTools/Console/Command/Common/FixRightsCommand.php
@@ -71,6 +71,8 @@ class FixRightsCommand extends \CliTools\Console\Command\AbstractCommand
                 $this->setRights($entry);
             }
         }
+
+        return 0;
     }
 
     /**

--- a/src/app/CliTools/Console/Command/Common/SelfUpdateCommand.php
+++ b/src/app/CliTools/Console/Command/Common/SelfUpdateCommand.php
@@ -89,5 +89,7 @@ class SelfUpdateCommand extends \CliTools\Console\Command\AbstractCommand
         }
 
         $updateService->update($force);
+
+        return 0;
     }
 }

--- a/src/app/CliTools/Console/Command/Docker/CleanupCommand.php
+++ b/src/app/CliTools/Console/Command/Docker/CleanupCommand.php
@@ -57,6 +57,8 @@ class CleanupCommand extends AbstractCommand
         $this->cleanDockerImages();
         $this->cleanDockerVolumes();
         $output->writeln('<comment>Cleanup finished</comment>');
+
+        return 0;
     }
 
     /**

--- a/src/app/CliTools/Console/Command/Mysql/BackupCommand.php
+++ b/src/app/CliTools/Console/Command/Mysql/BackupCommand.php
@@ -138,6 +138,8 @@ class BackupCommand extends AbstractCommand
         $command->executeInteractive();
 
         $output->writeln('<h2>Database "' . $database . '" stored to "' . $dumpFile . '"</h2>');
+
+        return 0;
     }
 
     /**

--- a/src/app/CliTools/Console/Command/Sync/AbstractCommand.php
+++ b/src/app/CliTools/Console/Command/Sync/AbstractCommand.php
@@ -409,6 +409,8 @@ abstract class AbstractCommand extends \CliTools\Console\Command\AbstractDockerC
         }
 
         $this->cleanup();
+
+        return 0;
     }
 
     /**

--- a/src/app/CliTools/Console/Command/TYPO3/DomainCommand.php
+++ b/src/app/CliTools/Console/Command/TYPO3/DomainCommand.php
@@ -121,6 +121,8 @@ class DomainCommand extends \CliTools\Console\Command\Mysql\AbstractCommand
             // ##############
             $this->runTaskForDomain($dbName);
         }
+
+        return 0;
     }
 
     /**

--- a/src/app/CliTools/Console/Command/Vagrant/ShareCommand.php
+++ b/src/app/CliTools/Console/Command/Vagrant/ShareCommand.php
@@ -189,7 +189,8 @@ class ShareCommand extends \CliTools\Console\Command\AbstractCommand
             $vagrant->addArgument('--ssh-once');
         }
 
-
         $vagrant->executeInteractive($opts);
+
+        return 0;
     }
 }


### PR DESCRIPTION
Else, this error pops up:

```
In Application.php line 259:
                                                                                                                                      
  Message: Return value of "CliTools\Console\Command\Sync\ServerCommand::execute()" should always be of the type int since Symfony 4  
  .4, NULL returned.                                                                                                                  
  File: phar:///usr/local/bin/ct/src/vendor/symfony/console/Command/Command.php                                                       
  Line: 258                                                                                                                           
```