### PR TITLE
Rename 'docker-compose' command

### DIFF
--- a/src/app/CliTools/Utility/DockerUtility.php
+++ b/src/app/CliTools/Utility/DockerUtility.php
@@ -44,7 +44,7 @@ class DockerUtility
      */
     public static function lookupDockerComposeContainerId($container)
     {
-        $command = new CommandBuilder('docker-compose', ['ps', '-q', $container]);
+        $command = new CommandBuilder('docker', ['compose', 'ps', '-q', $container]);
         $ret = $command->execute()->getOutputString();
 
         if (empty($ret)) {


### PR DESCRIPTION
It's 'docker compose' for some time now already.

Necessary for
```bash
ct mysql:querylog -D mysql
```