### PR TITLE
Add support for MARIADB_ROOT_PASSWORD env variable

### DIFF
--- a/src/app/CliTools/Console/Command/AbstractCommand.php
+++ b/src/app/CliTools/Console/Command/AbstractCommand.php
@@ -467,7 +467,11 @@ abstract class AbstractCommand extends Command
      */
     protected function getDockerMysqlRootPassword($container)
     {
-        return DockerUtility::getDockerContainerEnv($container, 'MYSQL_ROOT_PASSWORD');
+        $rootPassword = DockerUtility::getDockerContainerEnv($container, 'MYSQL_ROOT_PASSWORD');
+        if (empty($rootPassword)) {
+            $rootPassword = DockerUtility::getDockerContainerEnv($container, 'MARIADB_ROOT_PASSWORD');
+        }
+        return $rootPassword;
     }
 
     /**

--- a/src/app/CliTools/Console/Command/AbstractDockerCommand.php
+++ b/src/app/CliTools/Console/Command/AbstractDockerCommand.php
@@ -187,7 +187,11 @@ abstract class AbstractDockerCommand extends AbstractCommand
      */
     protected function getDockerMysqlRootPassword($container)
     {
-        return DockerUtility::getDockerContainerEnv($container, 'MYSQL_ROOT_PASSWORD');
+        $rootPassword = DockerUtility::getDockerContainerEnv($container, 'MYSQL_ROOT_PASSWORD');
+        if (empty($rootPassword)) {
+            $rootPassword = DockerUtility::getDockerContainerEnv($container, 'MARIADB_ROOT_PASSWORD');
+        }
+        return $rootPassword;
     }
 
     /**

--- a/src/app/CliTools/Console/Command/Sync/AbstractCommand.php
+++ b/src/app/CliTools/Console/Command/Sync/AbstractCommand.php
@@ -200,7 +200,11 @@ abstract class AbstractCommand extends \CliTools\Console\Command\AbstractDockerC
         }
 
         if ($useDockerMysql) {
-            $password = DockerUtility::getDockerContainerEnv($this->getLocalDockerContainer(\CliTools\Console\Command\AbstractDockerCommand::DOCKER_ALIAS_MYSQL ), 'MYSQL_ROOT_PASSWORD');
+            $container = $this->getLocalDockerContainer(\CliTools\Console\Command\AbstractDockerCommand::DOCKER_ALIAS_MYSQL);
+            $password = DockerUtility::getDockerContainerEnv($container, 'MYSQL_ROOT_PASSWORD');
+            if (empty($password)) {
+                $password = DockerUtility::getDockerContainerEnv($container, 'MARIADB_ROOT_PASSWORD');
+            }
             DatabaseConnection::setDsn('mysql:host=localhost', 'root', $password);
         }
     }


### PR DESCRIPTION
This makes sure the maria db env variable `MARIADB_ROOT_PASSWORD` is supported next to `MYSQL_ROOT_PASSWORD` when running this command:

```bash
ct mysql:querylog --docker-compose <container-name>
```

This command basically broke the moment we switched over from MySQL to MariaDB.