### PR TITLE
New option: `--mysql-keep-file`

### DIFF
--- a/src/app/CliTools/Console/Command/Sync/AbstractCommand.php
+++ b/src/app/CliTools/Console/Command/Sync/AbstractCommand.php
@@ -107,6 +107,12 @@ abstract class AbstractCommand extends \CliTools\Console\Command\AbstractDockerC
                  'Run only mysql'
              )
              ->addOption(
+                 'mysql-keep-file',
+                 null,
+                 InputOption::VALUE_NONE,
+                 'Keep SQL dump file in current working directory instead of temp directory'
+             )
+             ->addOption(
                  'rsync',
                  null,
                  InputOption::VALUE_NONE,

--- a/src/app/CliTools/Console/Command/Sync/ServerCommand.php
+++ b/src/app/CliTools/Console/Command/Sync/ServerCommand.php
@@ -155,7 +155,11 @@ class ServerCommand extends AbstractRemoteSyncCommand
             $localDatabase   = trim($localDatabase);
             $foreignDatabase = trim($foreignDatabase);
 
-            $dumpFile = $this->tempDir . '/' . $localDatabase . '.sql.dump';
+            if ($this->input->getOption('mysql-keep-file')) {
+                $dumpFile = getcwd() . '/.clisync-' . $foreignDatabase . '.sql.dump';
+            } else {
+                $dumpFile = $this->tempDir . '/' . $localDatabase . '.sql.dump';
+            }
 
             // ##########
             // Dump from server


### PR DESCRIPTION
Run `ct sync --mysql-keep-file` to write SQL file into local folder and not /tmp where it gets deleted on ending the command.